### PR TITLE
fix typo with providing widgetID as datasetID,

### DIFF
--- a/app/src/services/widget.service.js
+++ b/app/src/services/widget.service.js
@@ -214,7 +214,7 @@ class WidgetService {
         }
     }
 
-    static async delete(id) {
+    static async delete(id, dataset) {
         logger.debug(`[WidgetService]: Deleting widget with id: ${id}`);
         logger.info(`[DBACCESS-FIND]: ID: ${id}`);
         const widget = await Widget.findById(id).exec();
@@ -234,7 +234,7 @@ class WidgetService {
         }
         logger.info(`[DBACCESS-DELETE]: ID: ${id}`);
         try {
-            await WidgetService.deleteMetadata(id, widget._id);
+            await WidgetService.deleteMetadata(dataset, widget._id);
         } catch (err) {
             logger.error('Error removing metadata of the widget', err);
         }

--- a/app/src/services/widget.service.js
+++ b/app/src/services/widget.service.js
@@ -234,7 +234,7 @@ class WidgetService {
         }
         logger.info(`[DBACCESS-DELETE]: ID: ${id}`);
         try {
-            await WidgetService.deleteMetadata(dataset, widget._id);
+            await WidgetService.deleteMetadata(dataset || widget.dataset, widget._id);
         } catch (err) {
             logger.error('Error removing metadata of the widget', err);
         }


### PR DESCRIPTION
deleteMetadata expects first argument datasetID, so as widget._id == id, deleteMetadata sends a request to delete metadata from dataset with id widgetID.