### PR TITLE
Silence errors for screenshot failures when creating/updating widgets

### DIFF
--- a/app/src/services/widget.service.js
+++ b/app/src/services/widget.service.js
@@ -176,14 +176,16 @@ class WidgetService {
 
     static async generateThumbnail(widget) {
         logger.debug('[WidgetService]: Creating thumbnail');
+        let thumbURL = '';
         try {
             const widgetThumbnail = await ScreenshotService.takeWidgetScreenshot(widget);
-            widget.thumbnailUrl = widgetThumbnail.data.widgetThumbnail;
-            widget.save();
+            thumbURL = widgetThumbnail.data.widgetThumbnail;
         } catch (err) {
-            logger.error('Error generating widget thumbnail.');
-            throw new Error(`Error generating widget thumbnail: ${err.message}`);
+            logger.error(`Error generating widget thumbnail: ${err.message}`);
         }
+
+        widget.thumbnailUrl = thumbURL;
+        widget.save();
     }
 
 

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -142,53 +142,62 @@ const createWidgetInDB = ({
     apps, userId, datasetID, customerWidgetConfig
 }) => new Widget(createWidget(apps, userId, datasetID, customerWidgetConfig)).save();
 
-const mockDataset = (id, responseData = {}) => {
-    nock(`${process.env.CT_URL}/v1`)
-        .get(`/dataset/${id}`)
-        .reply(200, {
-            data: Object.assign({}, {
-                id,
-                type: 'dataset',
-                attributes: {
-                    name: 'Seasonal variability',
-                    slug: 'Seasonal-variability',
-                    type: null,
-                    subtitle: null,
-                    application: [
-                        'rw'
-                    ],
-                    dataPath: null,
-                    attributesPath: null,
-                    connectorType: 'rest',
-                    provider: 'cartodb',
-                    userId: '1a10d7c6e0a37126611fd7a7',
-                    connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
-                    tableName: 'rw_projections_20150309',
-                    status: 'pending',
-                    published: true,
-                    overwrite: false,
-                    verified: false,
-                    blockchain: {},
-                    mainDateField: null,
-                    env: 'production',
-                    geoInfo: false,
-                    protected: false,
-                    legend: {
-                        date: [],
-                        region: [],
-                        country: [],
-                        nested: []
-                    },
-                    clonedHost: {},
-                    errorMessage: null,
-                    taskId: null,
-                    updatedAt: '2018-11-19T11:45:44.405Z',
-                    dataLastUpdated: null,
-                    widgetRelevantProps: [],
-                    layerRelevantProps: []
-                }
-            }, responseData)
-        });
+const mockDataset = (id, responseData = {}, twice = false) => {
+    const data = Object.assign({}, {
+        id,
+        type: 'dataset',
+        attributes: {
+            name: 'Seasonal variability',
+            slug: 'Seasonal-variability',
+            type: null,
+            subtitle: null,
+            application: [
+                'rw'
+            ],
+            dataPath: null,
+            attributesPath: null,
+            connectorType: 'rest',
+            provider: 'cartodb',
+            userId: '1a10d7c6e0a37126611fd7a7',
+            connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
+            tableName: 'rw_projections_20150309',
+            status: 'pending',
+            published: true,
+            overwrite: false,
+            verified: false,
+            blockchain: {},
+            mainDateField: null,
+            env: 'production',
+            geoInfo: false,
+            protected: false,
+            legend: {
+                date: [],
+                region: [],
+                country: [],
+                nested: []
+            },
+            clonedHost: {},
+            errorMessage: null,
+            taskId: null,
+            updatedAt: '2018-11-19T11:45:44.405Z',
+            dataLastUpdated: null,
+            widgetRelevantProps: [],
+            layerRelevantProps: []
+        }
+    }, responseData);
+
+    const scope = nock(`${process.env.CT_URL}/v1`).get(`/dataset/${id}`);
+    if (twice) scope.twice();
+    scope.reply(200, { data });
+
+    return data;
+};
+
+const mockWebshot = (success = true, responseData = {}) => {
+    const data = Object.assign({}, { widgetThumbnail: 'http://thumbnail-url.com/file.png' }, responseData);
+    nock(`${process.env.CT_URL}`)
+        .post(uri => uri.match(/\/v1\/webshot\/widget\/(\w|-)*\/thumbnail/))
+        .reply(success ? 200 : 500, { data });
 };
 
 module.exports = {
@@ -201,5 +210,6 @@ module.exports = {
     ensureCorrectError,
     createWidgetMetadata,
     createVocabulary,
-    mockDataset
+    mockDataset,
+    mockWebshot
 };

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -1,3 +1,4 @@
+const nock = require('nock');
 const Widget = require('models/widget.model');
 const { WIDGET_CONFIG, USERS } = require('./test.constants');
 
@@ -141,6 +142,55 @@ const createWidgetInDB = ({
     apps, userId, datasetID, customerWidgetConfig
 }) => new Widget(createWidget(apps, userId, datasetID, customerWidgetConfig)).save();
 
+const mockDataset = (id, responseData = {}) => {
+    nock(`${process.env.CT_URL}/v1`)
+        .get(`/dataset/${id}`)
+        .reply(200, {
+            data: Object.assign({}, {
+                id,
+                type: 'dataset',
+                attributes: {
+                    name: 'Seasonal variability',
+                    slug: 'Seasonal-variability',
+                    type: null,
+                    subtitle: null,
+                    application: [
+                        'rw'
+                    ],
+                    dataPath: null,
+                    attributesPath: null,
+                    connectorType: 'rest',
+                    provider: 'cartodb',
+                    userId: '1a10d7c6e0a37126611fd7a7',
+                    connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
+                    tableName: 'rw_projections_20150309',
+                    status: 'pending',
+                    published: true,
+                    overwrite: false,
+                    verified: false,
+                    blockchain: {},
+                    mainDateField: null,
+                    env: 'production',
+                    geoInfo: false,
+                    protected: false,
+                    legend: {
+                        date: [],
+                        region: [],
+                        country: [],
+                        nested: []
+                    },
+                    clonedHost: {},
+                    errorMessage: null,
+                    taskId: null,
+                    updatedAt: '2018-11-19T11:45:44.405Z',
+                    dataLastUpdated: null,
+                    widgetRelevantProps: [],
+                    layerRelevantProps: []
+                }
+            }, responseData)
+        });
+};
+
 module.exports = {
     createWidget,
     getUUID,
@@ -150,5 +200,6 @@ module.exports = {
     createAuthCases,
     ensureCorrectError,
     createWidgetMetadata,
-    createVocabulary
+    createVocabulary,
+    mockDataset
 };

--- a/app/test/e2e/widget-create.spec.js
+++ b/app/test/e2e/widget-create.spec.js
@@ -5,7 +5,7 @@ const Widget = require('models/widget.model');
 const { USERS } = require('./utils/test.constants');
 
 const { getTestServer } = require('./utils/test-server');
-const { widgetConfig } = require('./utils/helpers');
+const { widgetConfig, mockDataset } = require('./utils/helpers');
 
 chai.should();
 
@@ -15,7 +15,6 @@ nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
 
 describe('Create widgets tests', () => {
-
     before(async () => {
         if (process.env.NODE_ENV !== 'test') {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
@@ -27,52 +26,7 @@ describe('Create widgets tests', () => {
     });
 
     it('Create a widget as an anonymous user should fail with a 401 error code', async () => {
-        nock(`${process.env.CT_URL}/v1`)
-            .get('/dataset/39f5dc1f-5e45-41d8-bcd5-96941c8a7e79')
-            .reply(200, {
-                data: {
-                    id: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
-                    type: 'dataset',
-                    attributes: {
-                        name: 'Seasonal variability',
-                        slug: 'Seasonal-variability',
-                        type: null,
-                        subtitle: null,
-                        application: [
-                            'rw'
-                        ],
-                        dataPath: null,
-                        attributesPath: null,
-                        connectorType: 'rest',
-                        provider: 'cartodb',
-                        userId: '1a10d7c6e0a37126611fd7a7',
-                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
-                        tableName: 'rw_projections_20150309',
-                        status: 'pending',
-                        published: true,
-                        overwrite: false,
-                        verified: false,
-                        blockchain: {},
-                        mainDateField: null,
-                        env: 'production',
-                        geoInfo: false,
-                        protected: false,
-                        legend: {
-                            date: [],
-                            region: [],
-                            country: [],
-                            nested: []
-                        },
-                        clonedHost: {},
-                        errorMessage: null,
-                        taskId: null,
-                        updatedAt: '2018-11-19T11:45:44.405Z',
-                        dataLastUpdated: null,
-                        widgetRelevantProps: [],
-                        layerRelevantProps: []
-                    }
-                }
-            });
+        mockDataset('39f5dc1f-5e45-41d8-bcd5-96941c8a7e79');
 
         const widget = {
             name: 'Widget default',
@@ -100,52 +54,7 @@ describe('Create widgets tests', () => {
     });
 
     it('Create a widget as an ADMIN should be successful', async () => {
-        nock(`${process.env.CT_URL}/v1`)
-            .get('/dataset/39f5dc1f-5e45-41d8-bcd5-96941c8a7e79')
-            .reply(200, {
-                data: {
-                    id: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
-                    type: 'dataset',
-                    attributes: {
-                        name: 'Seasonal variability',
-                        slug: 'Seasonal-variability',
-                        type: null,
-                        subtitle: null,
-                        application: [
-                            'rw'
-                        ],
-                        dataPath: null,
-                        attributesPath: null,
-                        connectorType: 'rest',
-                        provider: 'cartodb',
-                        userId: '1a10d7c6e0a37126611fd7a7',
-                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
-                        tableName: 'rw_projections_20150309',
-                        status: 'pending',
-                        published: true,
-                        overwrite: false,
-                        verified: false,
-                        blockchain: {},
-                        mainDateField: null,
-                        env: 'production',
-                        geoInfo: false,
-                        protected: false,
-                        legend: {
-                            date: [],
-                            region: [],
-                            country: [],
-                            nested: []
-                        },
-                        clonedHost: {},
-                        errorMessage: null,
-                        taskId: null,
-                        updatedAt: '2018-11-19T11:45:44.405Z',
-                        dataLastUpdated: null,
-                        widgetRelevantProps: [],
-                        layerRelevantProps: []
-                    }
-                }
-            });
+        mockDataset('39f5dc1f-5e45-41d8-bcd5-96941c8a7e79');
 
         const widget = {
             name: 'Widget default',
@@ -204,52 +113,7 @@ describe('Create widgets tests', () => {
     });
 
     it('Create a widget as an USER with a matching app should be successful', async () => {
-        nock(`${process.env.CT_URL}/v1`)
-            .get('/dataset/39f5dc1f-5e45-41d8-bcd5-96941c8a7e79')
-            .reply(200, {
-                data: {
-                    id: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
-                    type: 'dataset',
-                    attributes: {
-                        name: 'Seasonal variability',
-                        slug: 'Seasonal-variability',
-                        type: null,
-                        subtitle: null,
-                        application: [
-                            'rw'
-                        ],
-                        dataPath: null,
-                        attributesPath: null,
-                        connectorType: 'rest',
-                        provider: 'cartodb',
-                        userId: '1a10d7c6e0a37126611fd7a7',
-                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
-                        tableName: 'rw_projections_20150309',
-                        status: 'pending',
-                        published: true,
-                        overwrite: false,
-                        verified: false,
-                        blockchain: {},
-                        mainDateField: null,
-                        env: 'production',
-                        geoInfo: false,
-                        protected: false,
-                        legend: {
-                            date: [],
-                            region: [],
-                            country: [],
-                            nested: []
-                        },
-                        clonedHost: {},
-                        errorMessage: null,
-                        taskId: null,
-                        updatedAt: '2018-11-19T11:45:44.405Z',
-                        dataLastUpdated: null,
-                        widgetRelevantProps: [],
-                        layerRelevantProps: []
-                    }
-                }
-            });
+        mockDataset('39f5dc1f-5e45-41d8-bcd5-96941c8a7e79');
 
         const widget = {
             name: 'Widget default',
@@ -306,52 +170,7 @@ describe('Create widgets tests', () => {
     });
 
     it('Create a widget as an USER without a matching app should fail with HTTP 403', async () => {
-        nock(`${process.env.CT_URL}/v1`)
-            .get('/dataset/39f5dc1f-5e45-41d8-bcd5-96941c8a7e79')
-            .reply(200, {
-                data: {
-                    id: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
-                    type: 'dataset',
-                    attributes: {
-                        name: 'Seasonal variability',
-                        slug: 'Seasonal-variability',
-                        type: null,
-                        subtitle: null,
-                        application: [
-                            'potato'
-                        ],
-                        dataPath: null,
-                        attributesPath: null,
-                        connectorType: 'rest',
-                        provider: 'cartodb',
-                        userId: '1a10d7c6e0a37126611fd7a7',
-                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
-                        tableName: 'rw_projections_20150309',
-                        status: 'pending',
-                        published: true,
-                        overwrite: false,
-                        verified: false,
-                        blockchain: {},
-                        mainDateField: null,
-                        env: 'production',
-                        geoInfo: false,
-                        protected: false,
-                        legend: {
-                            date: [],
-                            region: [],
-                            country: [],
-                            nested: []
-                        },
-                        clonedHost: {},
-                        errorMessage: null,
-                        taskId: null,
-                        updatedAt: '2018-11-19T11:45:44.405Z',
-                        dataLastUpdated: null,
-                        widgetRelevantProps: [],
-                        layerRelevantProps: []
-                    }
-                }
-            });
+        mockDataset('39f5dc1f-5e45-41d8-bcd5-96941c8a7e79', { application: ['potato'] });
 
         const widget = {
             name: 'Widget default',
@@ -382,52 +201,7 @@ describe('Create widgets tests', () => {
     });
 
     it('Create a widget when taking a snapshot fails should return 200 OK with the created widget data', async () => {
-        nock(`${process.env.CT_URL}/v1`)
-            .get('/dataset/39f5dc1f-5e45-41d8-bcd5-96941c8a7e79')
-            .reply(200, {
-                data: {
-                    id: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
-                    type: 'dataset',
-                    attributes: {
-                        name: 'Seasonal variability',
-                        slug: 'Seasonal-variability',
-                        type: null,
-                        subtitle: null,
-                        application: [
-                            'rw'
-                        ],
-                        dataPath: null,
-                        attributesPath: null,
-                        connectorType: 'rest',
-                        provider: 'cartodb',
-                        userId: '1a10d7c6e0a37126611fd7a7',
-                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
-                        tableName: 'rw_projections_20150309',
-                        status: 'pending',
-                        published: true,
-                        overwrite: false,
-                        verified: false,
-                        blockchain: {},
-                        mainDateField: null,
-                        env: 'production',
-                        geoInfo: false,
-                        protected: false,
-                        legend: {
-                            date: [],
-                            region: [],
-                            country: [],
-                            nested: []
-                        },
-                        clonedHost: {},
-                        errorMessage: null,
-                        taskId: null,
-                        updatedAt: '2018-11-19T11:45:44.405Z',
-                        dataLastUpdated: null,
-                        widgetRelevantProps: [],
-                        layerRelevantProps: []
-                    }
-                }
-            });
+        mockDataset('39f5dc1f-5e45-41d8-bcd5-96941c8a7e79');
 
         const widget = {
             name: 'Widget default',

--- a/app/test/e2e/widget-create.spec.js
+++ b/app/test/e2e/widget-create.spec.js
@@ -381,6 +381,103 @@ describe('Create widgets tests', () => {
         response.body.errors[0].should.have.property('detail').and.equal('Forbidden');
     });
 
+    it('Create a widget when taking a snapshot fails should return 200 OK with the created widget data', async () => {
+        nock(`${process.env.CT_URL}/v1`)
+            .get('/dataset/39f5dc1f-5e45-41d8-bcd5-96941c8a7e79')
+            .reply(200, {
+                data: {
+                    id: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
+                    type: 'dataset',
+                    attributes: {
+                        name: 'Seasonal variability',
+                        slug: 'Seasonal-variability',
+                        type: null,
+                        subtitle: null,
+                        application: [
+                            'rw'
+                        ],
+                        dataPath: null,
+                        attributesPath: null,
+                        connectorType: 'rest',
+                        provider: 'cartodb',
+                        userId: '1a10d7c6e0a37126611fd7a7',
+                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
+                        tableName: 'rw_projections_20150309',
+                        status: 'pending',
+                        published: true,
+                        overwrite: false,
+                        verified: false,
+                        blockchain: {},
+                        mainDateField: null,
+                        env: 'production',
+                        geoInfo: false,
+                        protected: false,
+                        legend: {
+                            date: [],
+                            region: [],
+                            country: [],
+                            nested: []
+                        },
+                        clonedHost: {},
+                        errorMessage: null,
+                        taskId: null,
+                        updatedAt: '2018-11-19T11:45:44.405Z',
+                        dataLastUpdated: null,
+                        widgetRelevantProps: [],
+                        layerRelevantProps: []
+                    }
+                }
+            });
+
+        const widget = {
+            name: 'Widget default',
+            queryUrl: 'query/5be16fea-5b1a-4daf-a9e9-9dc1f6ea6d4e?sql=select * from crops',
+            application: ['rw'],
+            description: '',
+            source: '',
+            sourceUrl: 'http://foo.bar',
+            authors: '',
+            status: 1,
+            default: true,
+            published: true,
+            widgetConfig
+        };
+
+        nock(`${process.env.CT_URL}`)
+            .post(uri => uri.match(/\/v1\/webshot\/widget\/(\w|-)*\/thumbnail/))
+            .reply(500);
+
+        const response = await requester
+            .post(`/api/v1/widget`)
+            .send({
+                dataset: '39f5dc1f-5e45-41d8-bcd5-96941c8a7e79',
+                widget,
+                loggedUser: USERS.ADMIN
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+
+        const createdWidget = response.body.data;
+
+        createdWidget.attributes.name.should.equal(widget.name);
+        createdWidget.attributes.description.should.equal(widget.description);
+        createdWidget.attributes.dataset.should.equal('39f5dc1f-5e45-41d8-bcd5-96941c8a7e79');
+        createdWidget.attributes.sourceUrl.should.equal(widget.sourceUrl);
+        createdWidget.attributes.queryUrl.should.equal(widget.queryUrl);
+        createdWidget.attributes.widgetConfig.should.deep.equal(widget.widgetConfig);
+        new Date(createdWidget.attributes.updatedAt).should.equalDate(new Date());
+
+        const databaseWidget = await Widget.findById(createdWidget.id).exec();
+
+        databaseWidget.name.should.equal(widget.name);
+        databaseWidget.description.should.equal(widget.description);
+        databaseWidget.sourceUrl.should.equal(widget.sourceUrl);
+        databaseWidget.queryUrl.should.equal(widget.queryUrl);
+        databaseWidget.widgetConfig.should.deep.equal(widget.widgetConfig);
+        new Date(databaseWidget.updatedAt).should.equalDate(new Date());
+    });
+
     afterEach(() => {
         if (!nock.isDone()) {
             throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);

--- a/app/test/e2e/widget-update.spec.js
+++ b/app/test/e2e/widget-update.spec.js
@@ -372,6 +372,120 @@ describe('Update widgets tests', () => {
         new Date(databaseWidget.updatedAt).should.beforeDate(new Date());
     });
 
+    it('Updating a widget when taking a snapshot fails should still succeed', async () => {
+        const widgetOne = await new Widget(createWidget()).save();
+
+        nock(`${process.env.CT_URL}/v1`)
+            .get(`/dataset/${widgetOne.dataset}`)
+            .twice()
+            .reply(200, {
+                data: {
+                    id: widgetOne.dataset,
+                    type: 'dataset',
+                    attributes: {
+                        name: 'Seasonal variability',
+                        slug: 'Seasonal-variability',
+                        type: null,
+                        subtitle: null,
+                        application: [
+                            'rw'
+                        ],
+                        dataPath: null,
+                        attributesPath: null,
+                        connectorType: 'rest',
+                        provider: 'cartodb',
+                        userId: '1a10d7c6e0a37126611fd7a7',
+                        connectorUrl: 'https://wri-01.carto.com/tables/rw_projections_20150309/public',
+                        tableName: 'rw_projections_20150309',
+                        status: 'pending',
+                        published: true,
+                        overwrite: false,
+                        verified: false,
+                        blockchain: {},
+                        mainDateField: null,
+                        env: 'production',
+                        geoInfo: false,
+                        protected: false,
+                        legend: {
+                            date: [],
+                            region: [],
+                            country: [],
+                            nested: []
+                        },
+                        clonedHost: {},
+                        errorMessage: null,
+                        taskId: null,
+                        updatedAt: '2018-11-19T11:45:44.405Z',
+                        dataLastUpdated: null,
+                        widgetRelevantProps: [],
+                        layerRelevantProps: []
+                    }
+                }
+            });
+
+        const widget = {
+            name: 'Widget default',
+            queryUrl: 'query/5be16fea-5b1a-4daf-a9e9-9dc1f6ea6d4e?sql=select * from crops',
+            application: [
+                'rw'
+            ],
+            description: 'widget description',
+            source: 'widget source',
+            sourceUrl: 'http://bar.foo',
+            authors: '',
+            status: 1,
+            default: true,
+            published: true,
+            widgetConfig: { ...widgetConfig, someNewProp: 'someNewValue' }
+        };
+
+        let databaseWidget = await Widget.findById(widgetOne.id).exec();
+
+        databaseWidget.name.should.not.equal(widget.name);
+        databaseWidget.description.should.not.equal(widget.description);
+        databaseWidget.sourceUrl.should.not.equal(widget.sourceUrl);
+        databaseWidget.queryUrl.should.not.equal(widget.queryUrl);
+        databaseWidget.widgetConfig.should.not.deep.equal(widget.widgetConfig);
+        new Date(databaseWidget.updatedAt).should.beforeDate(new Date());
+
+        // Mock failed screenshot request
+        nock(`${process.env.CT_URL}`)
+            .post(uri => uri.match(/\/v1\/webshot\/widget\/(\w|-)*\/thumbnail/))
+            .reply(500);
+
+        const response = await requester
+            .patch(`/api/v1/widget/${widgetOne.id}`)
+            .send({
+                dataset: widgetOne.dataset,
+                widget,
+                loggedUser: USERS.ADMIN
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+
+        const updatedWidget = response.body.data;
+
+        updatedWidget.attributes.name.should.equal(widget.name);
+        updatedWidget.attributes.description.should.equal(widget.description);
+        updatedWidget.attributes.dataset.should.equal(widgetOne.dataset);
+        updatedWidget.attributes.sourceUrl.should.equal(widget.sourceUrl);
+        updatedWidget.attributes.queryUrl.should.equal(widget.queryUrl);
+        updatedWidget.attributes.widgetConfig.should.deep.equal(widget.widgetConfig);
+        updatedWidget.attributes.updatedAt.should.not.equal(databaseWidget.updatedAt);
+        new Date(updatedWidget.attributes.updatedAt).should.equalDate(new Date());
+
+        databaseWidget = await Widget.findById(widgetOne.id).exec();
+
+        databaseWidget.name.should.equal(widget.name);
+        databaseWidget.description.should.equal(widget.description);
+        databaseWidget.sourceUrl.should.equal(widget.sourceUrl);
+        databaseWidget.queryUrl.should.equal(widget.queryUrl);
+        databaseWidget.widgetConfig.should.deep.equal(widget.widgetConfig);
+        databaseWidget.widgetConfig.should.deep.equal(widget.widgetConfig);
+        new Date(databaseWidget.updatedAt).should.equalDate(new Date());
+    });
+
     afterEach(() => {
         if (!nock.isDone()) {
             throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169950696

## What does this PR fix?
This PR fixes 404 errors being thrown when creating/editing a widget related to problems with screenshot creation for that widget. If an error is reported when taking a screenshot, the error is reported in the logs, but it does not prevent the Widget MS response from being successful (the widget creation/update was being performed successfully anyways).

## What does this PR refactor?
Test cases for this bug were added, and some refactoring was performed in the associated test files - i.e. extracting dataset and webshot mocks into helper methods in the test helpers file.