### PR TITLE
Sort widgets by user role or name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 27/01/2020
+
+- Add possibility of sorting widgets by user fields (such as name or role).
+
 # 18/11/2019
 
 - Add support for dataset overwrite using multiple files in parallel.

--- a/app/src/models/widget.model.js
+++ b/app/src/models/widget.model.js
@@ -31,6 +31,8 @@ const Widget = new Schema({
     template: { type: Boolean, default: false },
     published: { type: Boolean, default: true },
     freeze: { type: Boolean, default: false },
+    userRole: { type: String, default: null, select: false },
+    userName: { type: String, default: null, select: false },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -186,9 +186,9 @@ class WidgetRouter {
             )));
         }
 
-        if (query['page[size]'] && query['page[size]'] > 100) {
-            ctx.throw(400, 'Invalid page size');
-        }
+        // if (query['page[size]'] && query['page[size]'] > 100) {
+        //     ctx.throw(400, 'Invalid page size');
+        // }
 
         if (Object.keys(query).find(el => el.indexOf('collection') >= 0)) {
             if (!userId) {

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -186,6 +186,10 @@ class WidgetRouter {
             )));
         }
 
+        if (query['page[size]'] && query['page[size]'] > 100) {
+            ctx.throw(400, 'Invalid page size');
+        }
+
         if (Object.keys(query).find(el => el.indexOf('collection') >= 0)) {
             if (!userId) {
                 ctx.throw(403, 'Collection filter not authorized');

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -186,6 +186,10 @@ class WidgetRouter {
             )));
         }
 
+        /**
+         * We'll want to limit the maximum page size in the future
+         * However, as this will cause a production BC break, we can't enforce it just now
+         */
         // if (query['page[size]'] && query['page[size]'] > 100) {
         //     ctx.throw(400, 'Invalid page size');
         // }

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -8,6 +8,7 @@ const WidgetValidator = require('validators/widget.validator');
 const WidgetNotValid = require('errors/widgetNotValid.error');
 const WidgetNotFound = require('errors/widgetNotFound.error');
 const WidgetProtected = require('errors/widgetProtected.error');
+const WidgetModel = require('models/widget.model');
 const { USER_ROLES } = require('app.constants');
 
 const router = new Router();
@@ -166,8 +167,22 @@ class WidgetRouter {
         const user = ctx.query.loggedUser && ctx.query.loggedUser !== 'null' ? JSON.parse(ctx.query.loggedUser) : null;
         const userId = user ? user.id : null;
         const isAdmin = ['ADMIN', 'SUPERADMIN'].includes(user && user.role);
-
         delete query.loggedUser;
+
+        if (ctx.query.sort && (ctx.query.sort.includes('user.role') || ctx.query.sort.includes('user.name'))) {
+            logger.debug('Detected sorting by user role or name');
+            if (!user || !isAdmin) {
+                ctx.throw(403, 'Sorting by user name or role not authorized.');
+                return;
+            }
+            const ids = await WidgetService.getAllWidgetsUserIds();
+            const users = await RelationshipsService.getUsersInfoByIds(ids);
+            await Promise.all(users.map(u => WidgetModel.updateMany(
+                { userId: u._id },
+                { userRole: u.role, userName: u.name },
+            )));
+        }
+
         if (Object.keys(query).find(el => el.indexOf('collection') >= 0)) {
             if (!userId) {
                 ctx.throw(403, 'Collection filter not authorized');

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -175,13 +175,18 @@ class WidgetRouter {
                 ctx.throw(403, 'Sorting by user name or role not authorized.');
                 return;
             }
+
+            // Reset all datasets' sorting columns
+            await WidgetModel.updateMany({}, { userRole: '', userName: '' });
+
+            // Fetch info to sort again
             const ids = await WidgetService.getAllWidgetsUserIds();
             const users = await RelationshipsService.getUsersInfoByIds(ids);
             await Promise.all(users.map(u => WidgetModel.updateMany(
                 { userId: u._id },
                 {
-                    userRole: u.role ? u.role.toLowerCase() : '',
-                    userName: u.name ? u.name.toLowerCase() : '',
+                    userRole: u.role ? u.role.toLowerCase() : '',
+                    userName: u.name ? u.name.toLowerCase() : '',
                 },
             )));
         }

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -179,7 +179,10 @@ class WidgetRouter {
             const users = await RelationshipsService.getUsersInfoByIds(ids);
             await Promise.all(users.map(u => WidgetModel.updateMany(
                 { userId: u._id },
-                { userRole: u.role, userName: u.name },
+                {
+                    userRole: u.role ? u.role.toLowerCase() : '',
+                    userName: u.name ? u.name.toLowerCase() : '',
+                },
             )));
         }
 

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -27,17 +27,13 @@ class RelationshipsService {
                         version: false
                     });
 
-                    if (!userData.data[0] || (!userData.data[0].name && !userData.data[0].email)) {
+                    if (!userData.data[0]) {
                         logger.warn(`Tried to use find-by-ids to load info for user with id ${widgets[i].userId} but the following was returned: ${JSON.stringify(user)}`);
                     } else {
-                        widgets[i].user = {
-                            name: userData.data[0].name,
-                            email: userData.data[0].email
-                        };
-                        if (user && user.role === 'ADMIN') {
-                            widgets[i].user.role = userData.data[0].role;
-                        }
-
+                        widgets[i].user = {};
+                        if (userData.data[0].name) widgets[i].user.name = userData.data[0].name;
+                        if (userData.data[0].email) widgets[i].user.email = userData.data[0].email;
+                        if (user && user.role === 'ADMIN') widgets[i].user.role = userData.data[0].role;
                         logger.info('Widgets including user data', widgets.map(el => el.toObject()));
                     }
                 }
@@ -113,7 +109,7 @@ class RelationshipsService {
             method: 'POST',
             json: true,
             version: false,
-            body: { ids: ids.sort() }
+            body: { ids }
         });
 
         return body.data;

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -4,6 +4,18 @@ const ctRegisterMicroservice = require('ct-register-microservice-node');
 
 class RelationshipsService {
 
+    static appendUserFieldIfExists(userData, userObject, field) {
+        if (userData[field]) userObject[field] = userData[field];
+    }
+
+    static formatWidgetOwner(userData, user) {
+        const userObject = {};
+        RelationshipsService.appendUserFieldIfExists(userData, userObject, 'name');
+        RelationshipsService.appendUserFieldIfExists(userData, userObject, 'email');
+        if (user && user.role === 'ADMIN') userObject.role = userData.role;
+        return userObject;
+    }
+
     static async getRelationships(widgets, includes, user) {
         logger.info(`Getting relationships of widgets: ${widgets}`);
         for (let i = 0; i < widgets.length; i++) {
@@ -30,10 +42,7 @@ class RelationshipsService {
                     if (!userData.data[0]) {
                         logger.warn(`Tried to use find-by-ids to load info for user with id ${widgets[i].userId} but the following was returned: ${JSON.stringify(user)}`);
                     } else {
-                        widgets[i].user = {};
-                        if (userData.data[0].name) widgets[i].user.name = userData.data[0].name;
-                        if (userData.data[0].email) widgets[i].user.email = userData.data[0].email;
-                        if (user && user.role === 'ADMIN') widgets[i].user.role = userData.data[0].role;
+                        widgets[i].user = RelationshipsService.formatWidgetOwner(userData.data[0], user);
                         logger.info('Widgets including user data', widgets.map(el => el.toObject()));
                     }
                 }

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -106,6 +106,19 @@ class RelationshipsService {
         }
     }
 
+    static async getUsersInfoByIds(ids) {
+        logger.debug('Fetching all users\' information');
+        const body = await ctRegisterMicroservice.requestToMicroservice({
+            uri: `/auth/user/find-by-ids`,
+            method: 'POST',
+            json: true,
+            version: false,
+            body: { ids: ids.sort() }
+        });
+
+        return body.data;
+    }
+
 }
 
 module.exports = RelationshipsService;

--- a/app/src/services/widget.service.js
+++ b/app/src/services/widget.service.js
@@ -391,10 +391,7 @@ class WidgetService {
     }
 
     static processSortParam(sort) {
-        let processedStr = sort;
-        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole');
-        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName');
-        return processedStr;
+        return sort.replace(/user.role/g, 'userRole').replace(/user.name/g, 'userName');
     }
 
     static getFilteredSort(sort) {

--- a/app/src/services/widget.service.js
+++ b/app/src/services/widget.service.js
@@ -391,7 +391,7 @@ class WidgetService {
     }
 
     static processSortParam(sort) {
-        return sort.replace(/user.role/g, 'userRole').replace(/user.name/g, 'userName');
+        return sort.replace(/user.role/g, 'userRole,_id').replace(/user.name/g, 'userName,_id');
     }
 
     static getFilteredSort(sort) {

--- a/app/src/services/widget.service.js
+++ b/app/src/services/widget.service.js
@@ -383,8 +383,22 @@ class WidgetService {
         return query;
     }
 
+    static async getAllWidgetsUserIds() {
+        logger.debug(`[WidgetService]: Getting the user ids of all widgets`);
+        const widgets = await Widget.find({}, 'userId').lean();
+        const userIds = widgets.map(w => w.userId);
+        return userIds.filter((item, idx) => userIds.indexOf(item) === idx && item !== 'legacy');
+    }
+
+    static processSortParam(sort) {
+        let processedStr = sort;
+        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole');
+        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName');
+        return processedStr;
+    }
+
     static getFilteredSort(sort) {
-        const sortParams = sort.split(',');
+        const sortParams = WidgetService.processSortParam(sort).split(',');
         const filteredSort = {};
         const widgetAttributes = Object.keys(Widget.schema.obj);
         sortParams.forEach((param) => {

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -137,9 +137,16 @@ const ensureCorrectWidget = (actualWidget, expectedWidget) => {
 
 const widgetConfig = WIDGET_CONFIG;
 
-const createWidgetInDB = ({
-    apps, userId, datasetID, customerWidgetConfig
-}) => new Widget(createWidget(apps, userId, datasetID, customerWidgetConfig)).save();
+const createWidgetInDB = async ({
+    apps,
+    userId,
+    datasetID,
+    customerWidgetConfig,
+}) => {
+    const data = createWidget(apps, userId, datasetID, customerWidgetConfig);
+    const savedWidget = await new Widget(data).save();
+    return Widget.findById(savedWidget._id);
+};
 
 module.exports = {
     createWidget,

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -95,8 +95,8 @@ const createVocabulary = widgetID => ({
     }
 });
 
-const createWidget = (apps = ['rw'], userId = '1a10d7c6e0a37126611fd7a7', datasetID, customerWidgetConfig) => {
-    const uuid = getUUID();
+const createWidget = (apps = ['rw'], userId = '1a10d7c6e0a37126611fd7a7', datasetID, customerWidgetConfig, widgetId) => {
+    const uuid = widgetId || getUUID();
     const datasetUuid = datasetID || getUUID();
 
     return {

--- a/app/test/e2e/utils/mock.js
+++ b/app/test/e2e/utils/mock.js
@@ -40,12 +40,9 @@ const createMockVocabulary = (mockVocabulary, datasetID, widgetID) => nock(proce
     });
 
 const createMockUser = mockUser => nock(process.env.CT_URL)
-    .post(`/auth/user/find-by-ids`, {
-        ids: mockUser.map(e => e.id)
-    })
-    .reply(200, {
-        data: mockUser
-    });
+    .post(`/auth/user/find-by-ids`, JSON.stringify({ ids: mockUser.map(e => e.id).sort() }))
+    .reply(200, { data: mockUser })
+    .log(console.log);
 
 module.exports = {
     createMockDataset,

--- a/app/test/e2e/utils/mock.js
+++ b/app/test/e2e/utils/mock.js
@@ -1,4 +1,5 @@
 const nock = require('nock');
+const intersection = require('lodash/intersection');
 const { DEFAULT_DATASET_ATTRIBUTES } = require('./test.constants');
 
 const createMockDataset = datasetID => nock(process.env.CT_URL)
@@ -39,10 +40,13 @@ const createMockVocabulary = (mockVocabulary, datasetID, widgetID) => nock(proce
         data: mockVocabulary,
     });
 
-const createMockUser = mockUser => nock(process.env.CT_URL)
-    .post(`/auth/user/find-by-ids`, JSON.stringify({ ids: mockUser.map(e => e.id).sort() }))
-    .reply(200, { data: mockUser })
-    .log(console.log);
+const createMockUser = users => nock(process.env.CT_URL)
+    .post(
+        `/auth/user/find-by-ids`,
+        body => intersection(body.ids, users.map(e => e._id.toString())).length === body.ids.length
+    )
+    .query(() => true)
+    .reply(200, { data: users });
 
 module.exports = {
     createMockDataset,

--- a/app/test/e2e/utils/mock.js
+++ b/app/test/e2e/utils/mock.js
@@ -43,7 +43,7 @@ const createMockVocabulary = (mockVocabulary, datasetID, widgetID) => nock(proce
 const createMockUser = users => nock(process.env.CT_URL)
     .post(
         `/auth/user/find-by-ids`,
-        body => intersection(body.ids, users.map(e => e._id.toString())).length === body.ids.length
+        body => intersection(body.ids, users.map(e => e.id.toString())).length === body.ids.length
     )
     .query(() => true)
     .reply(200, { data: users });

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -377,6 +377,7 @@ const DEFAULT_DATASET_ATTRIBUTES = {
 
 const USERS = {
     USER: {
+        _id: '1a10d7c6e0a37126611fd7a6',
         id: '1a10d7c6e0a37126611fd7a6',
         role: 'USER',
         provider: 'local',
@@ -395,6 +396,7 @@ const USERS = {
         }
     },
     MANAGER: {
+        _id: '1a10d7c6e0a37126611fd7a5',
         id: '1a10d7c6e0a37126611fd7a5',
         role: 'MANAGER',
         provider: 'local',
@@ -413,6 +415,7 @@ const USERS = {
         }
     },
     ADMIN: {
+        _id: '1a10d7c6e0a37126611fd7a7',
         id: '1a10d7c6e0a37126611fd7a7',
         role: 'ADMIN',
         provider: 'local',
@@ -431,6 +434,7 @@ const USERS = {
         }
     },
     SUPERADMIN: {
+        _id: '1a10d7c6e0a37126601fd7a7',
         id: '1a10d7c6e0a37126601fd7a7',
         role: 'SUPERADMIN',
         provider: 'local',

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -377,7 +377,7 @@ const DEFAULT_DATASET_ATTRIBUTES = {
 
 const USERS = {
     USER: {
-        id: '1a10d7c6e0a37126611fd7a7',
+        id: '1a10d7c6e0a37126611fd7a6',
         role: 'USER',
         provider: 'local',
         name: 'test user',
@@ -395,7 +395,7 @@ const USERS = {
         }
     },
     MANAGER: {
-        id: '1a10d7c6e0a37126611fd7a7',
+        id: '1a10d7c6e0a37126611fd7a5',
         role: 'MANAGER',
         provider: 'local',
         name: 'test manager',
@@ -417,6 +417,24 @@ const USERS = {
         role: 'ADMIN',
         provider: 'local',
         name: 'test admin',
+        email: 'user@control-tower.org',
+        extraUserData: {
+            apps: [
+                'rw',
+                'gfw',
+                'gfw-climate',
+                'prep',
+                'aqueduct',
+                'forest-atlas',
+                'data4sdgs'
+            ]
+        }
+    },
+    SUPERADMIN: {
+        id: '1a10d7c6e0a37126601fd7a7',
+        role: 'SUPERADMIN',
+        provider: 'local',
+        name: 'test super admin',
         email: 'user@control-tower.org',
         extraUserData: {
             apps: [

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -377,7 +377,6 @@ const DEFAULT_DATASET_ATTRIBUTES = {
 
 const USERS = {
     USER: {
-        _id: '1a10d7c6e0a37126611fd7a6',
         id: '1a10d7c6e0a37126611fd7a6',
         role: 'USER',
         provider: 'local',
@@ -396,7 +395,6 @@ const USERS = {
         }
     },
     MANAGER: {
-        _id: '1a10d7c6e0a37126611fd7a5',
         id: '1a10d7c6e0a37126611fd7a5',
         role: 'MANAGER',
         provider: 'local',
@@ -415,7 +413,6 @@ const USERS = {
         }
     },
     ADMIN: {
-        _id: '1a10d7c6e0a37126611fd7a7',
         id: '1a10d7c6e0a37126611fd7a7',
         role: 'ADMIN',
         provider: 'local',
@@ -434,7 +431,6 @@ const USERS = {
         }
     },
     SUPERADMIN: {
-        _id: '1a10d7c6e0a37126601fd7a7',
         id: '1a10d7c6e0a37126601fd7a7',
         role: 'SUPERADMIN',
         provider: 'local',

--- a/app/test/e2e/widget-get-sort-user-fields.spec.js
+++ b/app/test/e2e/widget-get-sort-user-fields.spec.js
@@ -1,0 +1,173 @@
+const nock = require('nock');
+const Widget = require('models/widget.model');
+const chai = require('chai');
+const { getTestServer } = require('./utils/test-server');
+const { createWidget } = require('./utils/helpers');
+const { createMockUser } = require('./utils/mock');
+const {
+    USERS: {
+        USER, MANAGER, ADMIN, SUPERADMIN
+    }
+} = require('./utils/test.constants');
+
+chai.should();
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+let requester;
+
+const mockUsersForSort = (users) => {
+    // Add _id property to provided users (some stuff uses _id, some uses id :shrug:)
+    const fullUsers = users.map(u => ({ ...u, _id: u.id }));
+
+    // Mock each user request (for includes=user)
+    fullUsers.map(user => createMockUser([user]));
+
+    // Mock all users request (for sorting by user role)
+    createMockUser(fullUsers);
+};
+
+const mockFourWidgetsForSorting = async () => {
+    await new Widget(createWidget(['rw'], USER.id)).save();
+    await new Widget(createWidget(['rw'], MANAGER.id)).save();
+    await new Widget(createWidget(['rw'], ADMIN.id)).save();
+    await new Widget(createWidget(['rw'], SUPERADMIN.id)).save();
+
+    mockUsersForSort([
+        USER, MANAGER, ADMIN, SUPERADMIN
+    ]);
+};
+
+describe('GET widgets sorted by user fields', () => {
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+    });
+
+    it('Getting widgets sorted by user.role ASC without authentication should return 403 Forbidden', async () => {
+        const response = await requester.get('/api/v1/widget').query({ sort: 'user.role' });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting widgets sorted by user.role ASC with user with role USER should return 403 Forbidden', async () => {
+        const response = await requester.get('/api/v1/widget').query({ sort: 'user.role', loggedUser: JSON.stringify(USER) });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting widgets sorted by user.role ASC with user with role MANAGER should return 403 Forbidden', async () => {
+        const response = await requester.get('/api/v1/widget').query({ sort: 'user.role', loggedUser: JSON.stringify(MANAGER) });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting widgets sorted by user.role ASC should return a list of widgets ordered by the role of the user who created the widget (happy case)', async () => {
+        await mockFourWidgetsForSorting();
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: 'user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(widget => widget.attributes.user.role).should.be.deep.equal(['ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
+    });
+
+    it('Getting widgets sorted by user.role DESC should return a list of widgets ordered by the role of the user who created the widget (happy case)', async () => {
+        await mockFourWidgetsForSorting();
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: '-user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(widget => widget.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN']);
+    });
+
+    it('Getting widgets sorted by user.name ASC should return a list of widgets ordered by the name of the user who created the widget (happy case)', async () => {
+        await mockFourWidgetsForSorting();
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: 'user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(widget => widget.attributes.user.name).should.be.deep.equal(['test admin', 'test manager', 'test super admin', 'test user']);
+    });
+
+    it('Getting widgets sorted by user.name DESC should return a list of widgets ordered by the name of the user who created the widget (happy case)', async () => {
+        await mockFourWidgetsForSorting();
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: '-user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(widget => widget.attributes.user.name).should.be.deep.equal(['test user', 'test super admin', 'test manager', 'test admin']);
+    });
+
+    it('Sorting widgets by user role ASC puts widgets without valid users in the beginning of the list', async () => {
+        await new Widget(createWidget(['rw'], USER.id)).save();
+        await new Widget(createWidget(['rw'], MANAGER.id)).save();
+        await new Widget(createWidget(['rw'], ADMIN.id)).save();
+        await new Widget(createWidget(['rw'], SUPERADMIN.id)).save();
+        const noUserWidget = await new Widget(createWidget(['rw'], 'legacy')).save();
+
+        mockUsersForSort([
+            USER, MANAGER, ADMIN, SUPERADMIN
+        ]);
+
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: 'user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+
+        const returnedNoUserWidget = response.body.data.find(widget => widget.id === noUserWidget._id);
+        response.body.data.indexOf(returnedNoUserWidget).should.be.equal(0);
+    });
+
+    it('Sorting widgets by user role DESC puts widgets without valid users in the end of the list', async () => {
+        await new Widget(createWidget(['rw'], USER.id)).save();
+        await new Widget(createWidget(['rw'], MANAGER.id)).save();
+        await new Widget(createWidget(['rw'], ADMIN.id)).save();
+        await new Widget(createWidget(['rw'], SUPERADMIN.id)).save();
+        const noUserWidget = await new Widget(createWidget(['rw'], 'legacy')).save();
+
+        mockUsersForSort([
+            USER, MANAGER, ADMIN, SUPERADMIN
+        ]);
+
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: '-user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+
+        const returnedNoUserWidget = response.body.data.find(widget => widget.id === noUserWidget._id);
+        response.body.data.indexOf(returnedNoUserWidget).should.be.equal(4);
+    });
+
+    afterEach(async () => {
+        await Widget.deleteMany({}).exec();
+
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+});

--- a/app/test/e2e/widget-get-sort-user-fields.spec.js
+++ b/app/test/e2e/widget-get-sort-user-fields.spec.js
@@ -163,6 +163,25 @@ describe('GET widgets sorted by user fields', () => {
         response.body.data.indexOf(returnedNoUserWidget).should.be.equal(4);
     });
 
+    it('Sorting widgets by user.name is case insensitive and returns a list of widgets ordered by the name of the user who created the widget', async () => {
+        const firstUser = { ...USER, name: 'Anthony' };
+        const secondUser = { ...MANAGER, name: 'bernard' };
+        const thirdUser = { ...ADMIN, name: 'Carlos' };
+        await new Widget(createWidget(['rw'], firstUser.id)).save();
+        await new Widget(createWidget(['rw'], secondUser.id)).save();
+        await new Widget(createWidget(['rw'], thirdUser.id)).save();
+        mockUsersForSort([firstUser, secondUser, thirdUser]);
+
+        const response = await requester.get('/api/v1/widget').query({
+            includes: 'user',
+            sort: 'user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(3);
+        response.body.data.map(widget => widget.attributes.user.name).should.be.deep.equal(['Anthony', 'bernard', 'Carlos']);
+    });
+
     afterEach(async () => {
         await Widget.deleteMany({}).exec();
 

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -141,8 +141,8 @@ describe('Get widgets tests', () => {
 
 
     it('Get all widgets with includes=user should be successful and return a list of widgets with associated user name and email (populated db, anonymous call)', async () => {
-        const widgetOne = await new Widget(createWidget()).save();
-        const widgetTwo = await new Widget(createWidget()).save();
+        const widgetOne = await new Widget(createWidget(undefined, ADMIN.id)).save();
+        const widgetTwo = await new Widget(createWidget(undefined, MANAGER.id)).save();
 
         createMockUser([ADMIN]);
         createMockUser([MANAGER]);
@@ -180,8 +180,8 @@ describe('Get widgets tests', () => {
     });
 
     it('Get all widgets with includes=user should be successful and return a list of widgets with associated user name and email (populated db, USER role)', async () => {
-        const widgetOne = await new Widget(createWidget()).save();
-        const widgetTwo = await new Widget(createWidget()).save();
+        const widgetOne = await new Widget(createWidget(undefined, ADMIN.id)).save();
+        const widgetTwo = await new Widget(createWidget(undefined, MANAGER.id)).save();
 
         createMockUser([ADMIN]);
         createMockUser([MANAGER]);
@@ -224,8 +224,8 @@ describe('Get widgets tests', () => {
     });
 
     it('Get all widgets with includes=user should be successful and return a list of widgets with associated user name and email (populated db, MANAGER role)', async () => {
-        const widgetOne = await new Widget(createWidget()).save();
-        const widgetTwo = await new Widget(createWidget()).save();
+        const widgetOne = await new Widget(createWidget(undefined, ADMIN.id)).save();
+        const widgetTwo = await new Widget(createWidget(undefined, MANAGER.id)).save();
 
         createMockUser([ADMIN]);
         createMockUser([MANAGER]);
@@ -268,8 +268,8 @@ describe('Get widgets tests', () => {
     });
 
     it('Get all widgets with includes=user should be successful and return a list of widgets with associated user name and email (populated db, ADMIN role)', async () => {
-        const widgetOne = await new Widget(createWidget()).save();
-        const widgetTwo = await new Widget(createWidget()).save();
+        const widgetOne = await new Widget(createWidget(undefined, ADMIN.id)).save();
+        const widgetTwo = await new Widget(createWidget(undefined, MANAGER.id)).save();
 
         createMockUser([ADMIN]);
         createMockUser([MANAGER]);

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -444,6 +444,12 @@ describe('Get widgets tests', () => {
         widgetOne.name.should.equal(responseWidgetOne.attributes.name);
     });
 
+    it('Getting widgets with page size over 100 should return 400 Bad Request', async () => {
+        const list = await requester.get('/api/v1/widget?page[size]=101');
+        list.status.should.equal(400);
+        list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
+    });
+
     afterEach(async () => {
         if (!nock.isDone()) {
             throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -444,6 +444,10 @@ describe('Get widgets tests', () => {
         widgetOne.name.should.equal(responseWidgetOne.attributes.name);
     });
 
+    /**
+     * We'll want to limit the maximum page size in the future
+     * However, as this will cause a production BC break, we can't enforce it just now
+     */
     // it('Getting widgets with page size over 100 should return 400 Bad Request', async () => {
     //     const list = await requester.get('/api/v1/widget?page[size]=101');
     //     list.status.should.equal(400);

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -363,21 +363,21 @@ describe('Get widgets tests', () => {
 
         createMockUser([{
             ...USER,
-            _id: widgetOne.userId,
+            id: widgetOne.userId,
             email: 'user-one@control-tower.org',
             name: 'test user'
         }]);
 
         createMockUser([{
             ...MANAGER,
-            _id: widgetTwo.userId,
+            id: widgetTwo.userId,
             name: undefined,
             email: 'user-two@control-tower.org'
         }]);
 
         createMockUser([{
             ...MANAGER,
-            _id: widgetThree.userId,
+            id: widgetThree.userId,
             name: 'user three',
             email: undefined
         }]);

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -362,45 +362,24 @@ describe('Get widgets tests', () => {
         const widgetThree = await new Widget(createWidget()).save();
 
         createMockUser([{
-            id: widgetOne.userId,
-            role: 'USER',
-            provider: 'local',
+            ...USER,
+            _id: widgetOne.userId,
             email: 'user-one@control-tower.org',
-            name: 'test user',
-            extraUserData: {
-                apps: [
-                    'rw',
-                    'gfw',
-                    'gfw-climate',
-                    'prep',
-                    'aqueduct',
-                    'forest-atlas'
-                ]
-            }
+            name: 'test user'
         }]);
 
         createMockUser([{
-            id: widgetTwo.userId,
-            role: 'MANAGER',
-            provider: 'local',
-            email: 'user-two@control-tower.org',
-            extraUserData: {
-                apps: [
-                    'rw'
-                ]
-            }
+            ...MANAGER,
+            _id: widgetTwo.userId,
+            name: undefined,
+            email: 'user-two@control-tower.org'
         }]);
 
         createMockUser([{
-            id: widgetThree.userId,
-            role: 'MANAGER',
-            provider: 'local',
+            ...MANAGER,
+            _id: widgetThree.userId,
             name: 'user three',
-            extraUserData: {
-                apps: [
-                    'rw'
-                ]
-            }
+            email: undefined
         }]);
 
         const response = await requester

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -444,11 +444,11 @@ describe('Get widgets tests', () => {
         widgetOne.name.should.equal(responseWidgetOne.attributes.name);
     });
 
-    it('Getting widgets with page size over 100 should return 400 Bad Request', async () => {
-        const list = await requester.get('/api/v1/widget?page[size]=101');
-        list.status.should.equal(400);
-        list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
-    });
+    // it('Getting widgets with page size over 100 should return 400 Bad Request', async () => {
+    //     const list = await requester.get('/api/v1/widget?page[size]=101');
+    //     list.status.should.equal(400);
+    //     list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
+    // });
 
     afterEach(async () => {
         if (!nock.isDone()) {

--- a/app/test/e2e/widget-update.spec.js
+++ b/app/test/e2e/widget-update.spec.js
@@ -163,7 +163,7 @@ describe('Update widgets tests', () => {
     });
 
     it('Update a widget as an USER with a matching app should be successful', async () => {
-        const widgetOne = await new Widget(createWidget()).save();
+        const widgetOne = await new Widget(createWidget(undefined, USERS.USER.id)).save();
 
         nock(`${process.env.CT_URL}/v1`)
             .get(`/dataset/${widgetOne.dataset}`)

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "koa-router": "^7.0.1",
     "koa-simple-healthcheck": "^0.0.1",
     "koa-validate": "^1.0.7",
+    "lodash": "^4.17.15",
     "microservice-cache-middleware": "^1.0.0",
     "mongoose": "^5.7.11",
     "mongoose-paginate": "^5.0.3",


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169174283

## What does this PR add?

This PR adds the possibility of sorting widgets according to the role or name of the user to whom the widget belongs.

It should be noted that, in order to accomplish this, **all widgets are updated with the current role and name of the user associated before sorting the collection**. This has an impact on the performance of the GET endpoint, but this impact is reduced when taking into account that this sort will be used in conjunction with `includes=user` option.

For reference, a benchmark was performed on the impact of this feature, including ~3.5k widgets created by ~330 different users. The results were the following:

* GET /widget => **~52.936ms**
* GET /widget?includes=user => **~189.834ms**
* GET /widget?includes=user&sort=user.role => **~475.058ms**