### PR TITLE
Remove query param usersRole which generated huge pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 09/03/2020
+
+- Remove `usersRole` query param which generated huge pagination links.
+
 # v1.1.1
 
 ## 28/02/2020

--- a/app/src/routes/api/v1/widget.router.js
+++ b/app/src/routes/api/v1/widget.router.js
@@ -241,6 +241,7 @@ class WidgetRouter {
         delete clonedQuery['page[number]'];
         delete clonedQuery.ids;
         delete clonedQuery.dataset;
+        delete clonedQuery.usersRole;
         const serializedQuery = serializeObjToQuery(clonedQuery) ? `?${serializeObjToQuery(clonedQuery)}&` : '?';
         const apiVersion = ctx.mountPath.split('/')[ctx.mountPath.split('/').length - 1];
         const link = `${ctx.request.protocol}://${ctx.request.host}/${apiVersion}${ctx.request.path}${serializedQuery}`;

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -610,6 +610,27 @@ describe('Get widgets tests', () => {
         response.body.should.have.property('data').and.be.an('array').and.length(0);
     });
 
+    it('Getting datasets with includes user and user role USER should not add the usersRole query param to the pagination links', async () => {
+        await new Widget(createWidget()).save();
+        nock(process.env.CT_URL).get('/auth/user/ids/USER').reply(200, { data: [USER.id] });
+
+        const response = await requester
+            .get(`/api/v1/widget`)
+            .query({
+                includes: 'user',
+                'user.role': 'USER',
+                loggedUser: JSON.stringify(ADMIN)
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('links').and.be.an('object');
+        response.body.links.should.have.property('first').and.not.contain('usersRole=');
+        response.body.links.should.have.property('last').and.not.contain('usersRole=');
+        response.body.links.should.have.property('prev').and.not.contain('usersRole=');
+        response.body.links.should.have.property('next').and.not.contain('usersRole=');
+        response.body.links.should.have.property('self').and.not.contain('usersRole=');
+    });
+
     /**
      * We'll want to limit the maximum page size in the future
      * However, as this will cause a production BC break, we can't enforce it just now

--- a/app/test/e2e/widget-get.spec.js
+++ b/app/test/e2e/widget-get.spec.js
@@ -610,7 +610,7 @@ describe('Get widgets tests', () => {
         response.body.should.have.property('data').and.be.an('array').and.length(0);
     });
 
-    it('Getting datasets with includes user and user role USER should not add the usersRole query param to the pagination links', async () => {
+    it('Getting widgets with includes user and user role USER should not add the usersRole query param to the pagination links', async () => {
         await new Widget(createWidget()).save();
         nock(process.env.CT_URL).get('/auth/user/ids/USER').reply(200, { data: [USER.id] });
 


### PR DESCRIPTION
This PR removes the query param `usersRole` from the generated pagination links which massively increased the size of the pagination links.

This PR is related to the following PT task: https://www.pivotaltracker.com/story/show/170841633