### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The endpoints provided by this microservice should now be available through Cont
 2 - Execute the following command to run Control tower:
 
 ```
-./widget.sh develop
+./widgetAdapter.sh develop
 ```
 
 The endpoints provided by this microservice should now be available through Control Tower's URL.

--- a/dev.env.sample
+++ b/dev.env.sample
@@ -1,2 +1,2 @@
 CT_URL=http://mymachine:9000
-LOCAL_URL=http://mymachine:35749
+LOCAL_URL=http://mymachine:3050

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -14,7 +14,7 @@ services:
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       MONGO_PORT_27017_TCP_ADDR: mongo
-      LOCAL_URL: http://mymachine:3055
+      LOCAL_URL: http://mymachine:3050
       FASTLY_ENABLED: "false"
     command: develop
     depends_on:


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Fix README typo
- Fix port typose